### PR TITLE
Fix debian compilation error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 ################################
 
 CC      = gcc
-CFLAGS  = -pthread -D_DEBUG -g -Wall -DHAVE_REMOTE -DHAVE_SNPRINTF -static
+CFLAGS  = -pthread -D_DEBUG -g -Wall -DHAVE_REMOTE -DHAVE_SNPRINTF 
 #flags for debugging: -D_DEBUG -g -Wall
 
 INCLUDE = -Ilibpcap/


### PR DESCRIPTION
Had the same issue as in <https://github.com/rpcapd-linux/rpcapd-linux/issues/8> on Debian 11 amd64 (libpcap0.8 at 1.10.0-2).

Renamed `sockmain` to `sockmaind` in *rpcapd.c*, which seems to solve the issue.